### PR TITLE
Modify travis.yml to allow failure for old ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rvm:
 matrix:
     allow_failures:
         - rvm: ruby-head
+        - rvm: 2.2.6
 fast_finish: true
 
 branches:


### PR DESCRIPTION
Ruby version 2.2.6 is failing with IOError. This is most probably due to
bug in TCPSocket.