### PR TITLE
Add bucket permission check

### DIFF
--- a/lib/cloudkeeper/aws/cloud.rb
+++ b/lib/cloudkeeper/aws/cloud.rb
@@ -20,6 +20,13 @@ module Cloudkeeper
         @ec2 = ec2service || ::Aws::EC2::Client.new
         @bucket = s3.bucket(Cloudkeeper::Aws::Settings['bucket-name'])
         bucket.create unless bucket.exists?
+        bucket_permissions!
+      end
+
+      def bucket_permissions!
+        s3.client.head_bucket(bucket: Cloudkeeper::Aws::Settings['bucket-name'])
+      rescue ::Aws::S3::Errors::Http301Error
+        raise Cloudkeeper::Aws::Errors::Backend::NoBucketPermissionError, 'Not enough permissions to use bucket'
       end
 
       # Uploads data in block AWS file with given name

--- a/lib/cloudkeeper/aws/core_connector.rb
+++ b/lib/cloudkeeper/aws/core_connector.rb
@@ -11,6 +11,8 @@ module Cloudkeeper
           => CloudkeeperGrpc::Constants::STATUS_CODE_INVALID_RESOURCE_STATE,
         Cloudkeeper::Aws::Errors::Backend::ImageImportError \
           => CloudkeeperGrpc::Constants::STATUS_CODE_FAILED_APPLIANCE_TRANSFER,
+        Cloudkeeper::Aws::Errors::Backend::NoBucketPermissionError \
+          => CloudkeeperGrpc::Constants::STATUS_CODE_UNKNOWN,
         Cloudkeeper::Aws::Errors::Backend::TimeoutError \
           => CloudkeeperGrpc::Constants::STATUS_CODE_FAILED_APPLIANCE_TRANSFER,
         Cloudkeeper::Aws::Errors::Backend::BackendError \

--- a/lib/cloudkeeper/aws/errors/backend.rb
+++ b/lib/cloudkeeper/aws/errors/backend.rb
@@ -8,6 +8,7 @@ module Cloudkeeper
         autoload :ImageImportError, 'cloudkeeper/aws/errors/backend/image_import_error'
         autoload :ApplianceNotFoundError, 'cloudkeeper/aws/errors/backend/appliance_not_found_error'
         autoload :MultipleAppliancesFoundError, 'cloudkeeper/aws/errors/backend/multiple_appliances_found_error'
+        autoload :NoBucketPermissionError, 'cloudkeeper/aws/errors/backend/no_bucket_permission_error'
       end
     end
   end

--- a/lib/cloudkeeper/aws/errors/backend/no_bucket_permission_error.rb
+++ b/lib/cloudkeeper/aws/errors/backend/no_bucket_permission_error.rb
@@ -1,0 +1,9 @@
+module Cloudkeeper
+  module Aws
+    module Errors
+      module Backend
+        class NoBucketPermissionError < BackendError; end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Aws ruby sdk checks if bucket exists but does not check if client is able to use it.
This commit adds check that checks for sufficient permissions to use bucket.