### PR TITLE
Add Name tag to AMIs

### DIFF
--- a/lib/cloudkeeper/aws/proto_helper.rb
+++ b/lib/cloudkeeper/aws/proto_helper.rb
@@ -6,6 +6,7 @@ module Cloudkeeper
       class << self
         APPLIANCE_PREFIX = 'cloudkeeper_appliance_'.freeze
         IMAGE_PREFIX = 'cloudkeeper_image_'.freeze
+        NAME_TAG_KEY = 'Name'.freeze
         EXTRA_APPLIANCE_TAGS = %i[description title].freeze
 
         def filter_tags(tags, prefix)
@@ -32,6 +33,7 @@ module Cloudkeeper
           tags += image_to_tags(image) if image
           tags << { key: Cloudkeeper::Aws::FilterHelper::TAG_CLOUDKEEPER_IDENTIFIER,
                     value: Cloudkeeper::Aws::Settings['identifier'] }
+          tags << { key: NAME_TAG_KEY, value: appliance_hash[:title] }
         end
 
         def appliance_from_tags(tags)

--- a/spec/unit/cloudkeeper/aws/proto_helper_spec.rb
+++ b/spec/unit/cloudkeeper/aws/proto_helper_spec.rb
@@ -36,7 +36,8 @@ module Cloudkeeper
          { key: 'cloudkeeper_appliance_base_mpuri', value: 'http://remotehost/base_mpuri' },
          { key: 'cloudkeeper_appliance_appid', value: '15' },
          { key: 'cloudkeeper_appliance_digest', value: 'c87q420' },
-         { key: 'cloudkeeper_identifier', value: 'cloudkeeper-aws' }] + image_tags
+         { key: 'cloudkeeper_identifier', value: 'cloudkeeper-aws' },
+         { key: 'Name', value: 'StubImage 0.1' }] + image_tags
       end
 
       describe '#appliance_to_tags' do


### PR DESCRIPTION
This will improve user experience, since they will be able to see
image name in AWS console.